### PR TITLE
Schema update

### DIFF
--- a/adres.json
+++ b/adres.json
@@ -1,296 +1,290 @@
 {
-    "Adres": {
-        "title": "Adres",
-        "description": "Een samengesteld adres van gegevens van een Nummeraanduiding, Openbare ruimte en Woonplaats in de Basisregistratie Adressen en Gebouwen (BAG).",
-        "type": "object",
-        "required": [
-            "identificatie",
-            "omschrijving",
-            "straatnaam",
-            "huisnummer",
-            "plaatsnaam",
-            "isHoofdadres",
-            "isGeregistreerdMet"
-        ],
-        "properties": {
-            "identificatie": {
-                "title": "identificatie",
-                "description": "De unieke aanduiding van een nummeraanduiding.",
-                "type": "string"
-            },
-            "omschrijving": {
-                "title": "omschrijving",
-                "description": "De unieke aanduiding van een nummeraanduiding.",
-                "type": "string"
-            },
-            "straatnaam": {
-                "title": "straatnaam",
-                "description": "Een naam die aan een openbare ruimte is toegekend in een daartoe strekkend formeel gemeentelijk besluit.",
-                "type": "string",
-                "minLength": "1"
-            },
-            "huisnummer": {
-                "title": "huisnummer",
-                "description": "Een door of namens het gemeentebestuur ten aanzien van een adresseerbaar object toegekende nummering.",
-                "type": "integer",
-                "minLength": "1",
-                "pattern": "^[1-9][0-9]{0,4}$"
-            },
-            "huisletter": {
-                "title": "huisletter",
-                "description": "Een door of namens het gemeentebestuur ten aanzien van een adresseerbaar object toegekende toevoeging aan een huisnummer in de vorm van een alfanumeriek teken.",
-                "type": [
-                    "string",
-                    null
-                ],
-                "pattern": "^[a-zA-Z]{1}$"
-            },
-            "huisnummertoevoeging": {
-                "title": "huisnummertoevoeging",
-                "description": "Een door of namens het gemeentebestuur ten aanzien van een adresseerbaar object toegekende nadere toevoeging aan een huisnummer of een combinatie van huisnummer en huisletter.",
-                "type": [
-                    "string",
-                    null
-                ],
-                "minLength": "1",
-                "pattern": "^[0-9a-zA-Z]{1,4}$"
-            },
-            "postcode": {
-                "title": "postcode",
-                "description": "De door PostNL vastgestelde code behorende bij een bepaalde combinatie van een straatnaam en een huisnummer.",
-                "type": [
-                    "string",
-                    null
-                ],
-                "pattern": "^[1-9][0-9]{3}[A-Z]{2}$"
-            },
-            "plaatsnaam": {
-                "title": "plaatsnaam",
-                "description": "De benaming van een door het gemeentebestuur aangewezen woonplaats.",
-                "type": "string",
-                "minLength": "1"
-            },
-            "isHoofdadres": {
-                "title": "isHoofdadres",
-                "description": "Indicatie of het adres een hoofdadres is.",
-                "type": "boolean"
-            },
-            "isGeregistreerdMet": {
-                "title": "isGeregistreerdMet",
-                "$ref": "#/components/schemas/Registratiegegevens"
-            }
+    "$id": "https://raw.githubusercontent.com/Geonovum/WaU-UC1/main/adres.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Adres",
+    "description": "Een samengesteld adres van gegevens van een Nummeraanduiding, Openbare ruimte en Woonplaats in de Basisregistratie Adressen en Gebouwen (BAG).",
+    "type": "object",
+    "required": [
+        "identificatie",
+        "omschrijving",
+        "straatnaam",
+        "huisnummer",
+        "plaatsnaam",
+        "isHoofdadres"
+    ],
+    "properties": {
+        "identificatie": {
+            "title": "identificatie",
+            "description": "De unieke aanduiding van een nummeraanduiding.",
+            "type": "string",
+            "minLength": "1"
+        },
+        "omschrijving": {
+            "title": "omschrijving",
+            "description": "De unieke aanduiding van een nummeraanduiding.",
+            "type": "string",
+            "minLength": "1"
+        },
+        "straatnaam": {
+            "title": "straatnaam",
+            "description": "Een naam die aan een openbare ruimte is toegekend in een daartoe strekkend formeel gemeentelijk besluit.",
+            "type": "string",
+            "minLength": "1"
+        },
+        "huisnummer": {
+            "title": "huisnummer",
+            "description": "Een door of namens het gemeentebestuur ten aanzien van een adresseerbaar object toegekende nummering.",
+            "type": "integer",
+            "min": 1,
+            "max": 99999
+        },
+        "huisletter": {
+            "title": "huisletter",
+            "description": "Een door of namens het gemeentebestuur ten aanzien van een adresseerbaar object toegekende toevoeging aan een huisnummer in de vorm van een alfanumeriek teken.",
+            "type": "string",
+            "pattern": "^[a-zA-Z]{1}$"
+        },
+        "huisnummertoevoeging": {
+            "title": "huisnummertoevoeging",
+            "description": "Een door of namens het gemeentebestuur ten aanzien van een adresseerbaar object toegekende nadere toevoeging aan een huisnummer of een combinatie van huisnummer en huisletter.",
+            "type": "string",
+            "minLength": "1",
+            "pattern": "^[0-9a-zA-Z]{1,4}$"
+        },
+        "postcode": {
+            "title": "postcode",
+            "description": "De door PostNL vastgestelde code behorende bij een bepaalde combinatie van een straatnaam en een huisnummer.",
+            "type": "string",
+            "pattern": "^[1-9][0-9]{3}[A-Z]{2}$"
+        },
+        "plaatsnaam": {
+            "title": "plaatsnaam",
+            "description": "De benaming van een door het gemeentebestuur aangewezen woonplaats.",
+            "type": "string",
+            "minLength": "1"
+        },
+        "isHoofdadres": {
+            "title": "isHoofdadres",
+            "description": "Indicatie of het adres een hoofdadres is.",
+            "type": "boolean"
+        },
+        "isGeregistreerdMet": {
+            "title": "isGeregistreerdMet",
+            "$ref": "#/$defs/Registratiegegevens"
         }
     },
-    "Registratiegegevens": {
-        "title": "Registratiegegevens",
-        "description": "Gegevens inzake de registratie van een object.",
-        "type": "object",
-        "required": ["bestaatUit"],
-        "properties": {
-            "bestaatUit": {
-                "title": "bestaatUit",
-                "description": "Registratiegevens bestaat uit één of meer Orkestratiegegevens.",
-                "type": "array",
-                "items": {"$ref": "#/components/schemas/GeorkestreerdGegeven"},
-                "minItems": "1"
-            }
-        }
-    },
-    "GeorkestreerdGegeven": {
-        "title": "GeorkestreerdGegeven",
-        "description": "Een gegeven dat is ontstaan/verkregen middels het orkestreren van brongegevens.",
-        "type": "object",
-        "required": [
-            "kenmerk",
-            "heeftAlsOnderwerp"
-        ],
-        "properties": {
-            "kenmerk": {
-                "title": "kenmerk",
-                "description": "De naam van het attribuut of de relatie van het Orkestratiegegeven.",
-                "type": "string"
-            },
-            "isAfgeleidVan": {
-                "title": "isAfgeleidVan",
-                "description": "Orkestratiegegeven is afgeleid van één of meer Brongegevens.",
-                "type": "array",
-                "items": {"$ref": "#/components/schemas/Brongegeven"},
-                "minItems": "0"
-            },
-            "heeftAlsOnderwerp": {
-                "title": "heeftAlsOnderwerp",
-                "description": "Orkestratiegegeven maakt deel uit van een Onderwerp.",
-                "$ref": "#/components/schemas/Adres"
-            }
-        }
-    },
-    "GeorkesteerdCharacterStringGegeven": {
-        "title": "GeorkesteerdCharacterStringGegeven",
-        "description": "GeorkestreerdGegeven met als waarde een CharacterString.",
-        "type": "object",
-        "allOf": [
-            {"$ref": "#/components/schemas/GeorkestreerdGegeven"},
-            {
-                "required": ["waarde"],
-                "properties": {
-                    "waarde": {
-                        "title": "waarde",
-                        "type": "string"
-                    }
+    "$defs": {
+        "Registratiegegevens": {
+            "title": "Registratiegegevens",
+            "description": "Gegevens inzake de registratie van een object.",
+            "type": "object",
+            "required": ["bestaatUit"],
+            "properties": {
+                "bestaatUit": {
+                    "title": "bestaatUit",
+                    "description": "Registratiegevens bestaat uit één of meer Orkestratiegegevens.",
+                    "type": "array",
+                    "items": {"$ref": "#/$defs/GeorkestreerdGegeven"},
+                    "minItems": "1"
                 }
             }
-        ]
-    },
-    "GeorkestreerdIntegerGegeven": {
-        "title": "GeorkestreerdIntegerGegeven",
-        "description": "GeorkestreerdGegeven met als waarde een Integer.",
-        "type": "object",
-        "allOf": [
-            {"$ref": "#/components/schemas/GeorkestreerdGegeven"},
-            {
-                "required": ["waarde"],
-                "properties": {
-                    "waarde": {
-                        "title": "waarde",
-                        "type": "integer"
-                    }
+        },
+        "GeorkestreerdGegeven": {
+            "title": "GeorkestreerdGegeven",
+            "description": "Een gegeven dat is ontstaan/verkregen middels het orkestreren van brongegevens.",
+            "type": "object",
+            "required": [
+                "kenmerk",
+                "heeftAlsOnderwerp"
+            ],
+            "properties": {
+                "kenmerk": {
+                    "title": "kenmerk",
+                    "description": "De naam van het attribuut of de relatie van het Orkestratiegegeven.",
+                    "type": "string"
+                },
+                "isAfgeleidVan": {
+                    "title": "isAfgeleidVan",
+                    "description": "Orkestratiegegeven is afgeleid van één of meer Brongegevens.",
+                    "type": "array",
+                    "items": {"$ref": "#/$defs/Brongegeven"},
+                    "minItems": "0"
+                },
+                "heeftAlsOnderwerp": {
+                    "title": "heeftAlsOnderwerp",
+                    "description": "Orkestratiegegeven maakt deel uit van een Onderwerp.",
+                    "$ref": "#/$defs/Adres"
                 }
             }
-        ]
-    },
-    "GeorkestreerdBooleanGegeven": {
-        "title": "GeorkestreerdBooleanGegeven",
-        "description": "GeorkestreerdGegeven met als waarde een Boolean.",
-        "type": "object",
-        "allOf": [
-            {"$ref": "#/components/schemas/GeorkestreerdGegeven"},
-            {
-                "required": ["waarde"],
-                "properties": {
-                    "waarde": {
-                        "title": "waarde",
-                        "type": "boolean"
+        },
+        "GeorkesteerdCharacterStringGegeven": {
+            "title": "GeorkesteerdCharacterStringGegeven",
+            "description": "GeorkestreerdGegeven met als waarde een CharacterString.",
+            "type": "object",
+            "allOf": [
+                {"$ref": "#/$defs/GeorkestreerdGegeven"},
+                {
+                    "required": ["waarde"],
+                    "properties": {
+                        "waarde": {
+                            "title": "waarde",
+                            "type": "string"
+                        }
                     }
                 }
-            }
-        ]
-    },
-    "Brongegeven": {
-        "title": "Brongegeven",
-        "description": "Een gegeven van een Bronobject.",
-        "type": "object",
-        "required": [
-            "kenmerk",
-            "heeftAlsHerkomst",
-            "heeftAlsOnderwerp"
-        ],
-        "properties": {
-            "kenmerk": {
-                "title": "kenmerk",
-                "description": "De naam van het attribuut of de relatie van het Brongegeven.",
-                "type": "string"
-            },
-            "heeftAlsHerkomst": {
-                "title": "heeftAlsHerkomst",
-                "description": "Een Brongegeven heeft als herkomst een Bronregistratie.",
-                "$ref": "#/components/schemas/Bronregistratie"
-            },
-            "heeftAlsOnderwerp": {
-                "title": "heeftAlsOnderwerp",
-                "description": "Brongegeven hoort bij één Bronobject.",
-                "$ref": "#/components/schemas/Bronobject"
-            }
-        }
-    },
-    "BronCharacterStringGegeven": {
-        "title": "BronCharacterStringGegeven",
-        "description": "Brongegeven met als waarde een CharacterString.",
-        "type": "object",
-        "allOf": [
-            {"$ref": "#/components/schemas/Brongegeven"},
-            {
-                "required": ["waarde"],
-                "properties": {
-                    "waarde": {
-                        "title": "waarde",
-                        "type": "string"
+            ]
+        },
+        "GeorkestreerdIntegerGegeven": {
+            "title": "GeorkestreerdIntegerGegeven",
+            "description": "GeorkestreerdGegeven met als waarde een Integer.",
+            "type": "object",
+            "allOf": [
+                {"$ref": "#/$defs/GeorkestreerdGegeven"},
+                {
+                    "required": ["waarde"],
+                    "properties": {
+                        "waarde": {
+                            "title": "waarde",
+                            "type": "integer"
+                        }
                     }
                 }
-            }
-        ]
-    },
-    "BronIntegerGegeven": {
-        "title": "BronIntegerGegeven",
-        "description": "Brongegeven met als waarde een Integer.",
-        "type": "object",
-        "allOf": [
-            {"$ref": "#/components/schemas/Brongegeven"},
-            {
-                "required": ["waarde"],
-                "properties": {
-                    "waarde": {
-                        "title": "waarde",
-                        "type": "integer"
+            ]
+        },
+        "GeorkestreerdBooleanGegeven": {
+            "title": "GeorkestreerdBooleanGegeven",
+            "description": "GeorkestreerdGegeven met als waarde een Boolean.",
+            "type": "object",
+            "allOf": [
+                {"$ref": "#/$defs/GeorkestreerdGegeven"},
+                {
+                    "required": ["waarde"],
+                    "properties": {
+                        "waarde": {
+                            "title": "waarde",
+                            "type": "boolean"
+                        }
                     }
                 }
-            }
-        ]
-    },
-    "BronRelatieGegeven": {
-        "title": "BronRelatieGegeven",
-        "description": "Brongegeven met als waarde een relatie naar een Bronobject.",
-        "type": "object",
-        "allOf": [
-            {"$ref": "#/components/schemas/Brongegeven"},
-            {
-                "required": ["heeftAlsWaarde"],
-                "properties": {
-                    "heeftAlsWaarde": {
-                        "title": "heeftAlsWaarde",
-                        "description": "BronRelatieGegeven heeft als waarde een Bronobject.",
-                        "$ref": "#/components/schemas/Bronobject"
-                    }
+            ]
+        },
+        "Brongegeven": {
+            "title": "Brongegeven",
+            "description": "Een gegeven van een Bronobject.",
+            "type": "object",
+            "required": [
+                "kenmerk",
+                "heeftAlsHerkomst",
+                "heeftAlsOnderwerp"
+            ],
+            "properties": {
+                "kenmerk": {
+                    "title": "kenmerk",
+                    "description": "De naam van het attribuut of de relatie van het Brongegeven.",
+                    "type": "string"
+                },
+                "heeftAlsHerkomst": {
+                    "title": "heeftAlsHerkomst",
+                    "description": "Een Brongegeven heeft als herkomst een Bronregistratie.",
+                    "$ref": "#/$defs/Bronregistratie"
+                },
+                "heeftAlsOnderwerp": {
+                    "title": "heeftAlsOnderwerp",
+                    "description": "Brongegeven hoort bij één Bronobject.",
+                    "$ref": "#/$defs/Bronobject"
                 }
             }
-        ]
-    },
-    "Bronobject": {
-        "title": "Bronobject",
-        "description": "Een object in een Bronregistratie.",
-        "type": "object",
-        "required": [
-            "type",
-            "identificatie"
-        ],
-        "properties": {
-            "type": {
-                "title": "type",
-                "description": "Het type Bronobject in de Bronregistratie.",
-                "type": "string"
-            },
-            "identificatie": {
-                "title": "identificatie",
-                "description": "De identificatie van het Bronobject in de Bronregistratie.",
-                "type": "string"
+        },
+        "BronCharacterStringGegeven": {
+            "title": "BronCharacterStringGegeven",
+            "description": "Brongegeven met als waarde een CharacterString.",
+            "type": "object",
+            "allOf": [
+                {"$ref": "#/$defs/Brongegeven"},
+                {
+                    "required": ["waarde"],
+                    "properties": {
+                        "waarde": {
+                            "title": "waarde",
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
+        },
+        "BronIntegerGegeven": {
+            "title": "BronIntegerGegeven",
+            "description": "Brongegeven met als waarde een Integer.",
+            "type": "object",
+            "allOf": [
+                {"$ref": "#/$defs/Brongegeven"},
+                {
+                    "required": ["waarde"],
+                    "properties": {
+                        "waarde": {
+                            "title": "waarde",
+                            "type": "integer"
+                        }
+                    }
+                }
+            ]
+        },
+        "BronRelatieGegeven": {
+            "title": "BronRelatieGegeven",
+            "description": "Brongegeven met als waarde een relatie naar een Bronobject.",
+            "type": "object",
+            "allOf": [
+                {"$ref": "#/$defs/Brongegeven"},
+                {
+                    "required": ["heeftAlsWaarde"],
+                    "properties": {
+                        "heeftAlsWaarde": {
+                            "title": "heeftAlsWaarde",
+                            "description": "BronRelatieGegeven heeft als waarde een Bronobject.",
+                            "$ref": "#/$defs/Bronobject"
+                        }
+                    }
+                }
+            ]
+        },
+        "Bronobject": {
+            "title": "Bronobject",
+            "description": "Een object in een Bronregistratie.",
+            "type": "object",
+            "required": [
+                "type",
+                "identificatie"
+            ],
+            "properties": {
+                "type": {
+                    "title": "type",
+                    "description": "Het type Bronobject in de Bronregistratie.",
+                    "type": "string"
+                },
+                "identificatie": {
+                    "title": "identificatie",
+                    "description": "De identificatie van het Bronobject in de Bronregistratie.",
+                    "type": "string"
+                }
             }
-        }
-    },
-    "Bronregistratie": {
-        "title": "Bronregistratie",
-        "description": "Een registratie, welke als bron heeft gediend voor de orkestratie van brongegevens.",
-        "type": "object",
-        "required": ["naam"],
-        "properties": {
-            "naam": {
-                "title": "naam",
-                "description": "De naam van de Bronregistratie.",
-                "$ref": "#/components/schemas/Registratie"
+        },
+        "Bronregistratie": {
+            "title": "Bronregistratie",
+            "description": "Een registratie, welke als bron heeft gediend voor de orkestratie van brongegevens.",
+            "type": "object",
+            "required": ["naam"],
+            "properties": {
+                "naam": {
+                    "title": "naam",
+                    "description": "De naam van de Bronregistratie.",
+                    "$ref": "#/$defs/Registratie"
+                }
             }
-        }
-    },
-    "Registratie": {
-        "title": "Registratie",
-        "description": "Waardenlijst voor Bronregistratie.",
-        "enum": ["BAG"]
+        },
+        "Registratie": {
+            "title": "Registratie",
+            "description": "Waardenlijst voor Bronregistratie.",
+            "enum": ["BAG"]
+        }    
     }
 }


### PR DESCRIPTION
Changes:

- Update structure to conform to JSON Schema Core requirements.
- Add `$schema` und `$id` keywords.
- Removed `isGeregistreerdMet` from required properties, since it should be possible to also expose the data without the provenance information.
- Added `minLength: 1` to required string properties where it was not present.
- Adjusted `huisnummer` definition to reflect that it is an integer.
- Removed `null` from optional properties. The current definition would allow both a missing member or a member with a `null` value. There should be only one approach and typically the first option is used.